### PR TITLE
refactor: extract json-ld helper to module

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,6 +27,9 @@ from pathlib import Path
 from dotenv import load_dotenv
 from openai import OpenAI
 
+# Утилиты
+from utils.json_ld import _extract_from_json_ld
+
 # ========= ЛОГИ =========
 logging.basicConfig(
     level=logging.INFO,
@@ -5397,43 +5400,6 @@ def _parse_av_ru_html(html: str) -> Optional[Dict[str, Any]]:
     except Exception as e:
         logger.warning(f"Error parsing av.ru HTML: {e}")
         
-    return None
-
-def _extract_from_json_ld(data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    """Извлекает данные из JSON-LD структуры"""
-    if not isinstance(data, dict):
-        return None
-        
-    name = (data.get("name") or data.get("headline") or "").strip()
-    brand = data.get("brand")
-    if isinstance(brand, dict):
-        brand = brand.get("name")
-        
-    nutrition = data.get("nutrition") or {}
-    
-    def get_nutrition_value(key):
-        value = nutrition.get(key)
-        if isinstance(value, dict):
-            value = value.get("@value") or value.get("value")
-        try:
-            return float(str(value).replace(',', '.')) if value is not None else None
-        except:
-            return None
-            
-    kcal = get_nutrition_value("calories") or get_nutrition_value("energy") or get_nutrition_value("caloriesContent")
-    protein = get_nutrition_value("proteinContent")
-    fat = get_nutrition_value("fatContent") 
-    carbs = get_nutrition_value("carbohydrateContent")
-    
-    if any(v is not None for v in (kcal, protein, fat, carbs)):
-        return {
-            "name": name or "Продукт",
-            "brand": brand,
-            "kcal_100g": kcal,
-            "protein_100g": protein,
-            "fat_100g": fat,
-            "carbs_100g": carbs,
-        }
     return None
 
 def _extract_from_state(product: Dict[str, Any]) -> Optional[Dict[str, Any]]:

--- a/tests/test_json_ld.py
+++ b/tests/test_json_ld.py
@@ -1,22 +1,8 @@
-import ast
-import pathlib
-from typing import Any, Dict, Optional
-import pytest
+import sys
+from pathlib import Path
 
-# Load _extract_from_json_ld function from main.py without executing the whole module
-MAIN_PATH = pathlib.Path(__file__).resolve().parent.parent / "main.py"
-with MAIN_PATH.open("r", encoding="utf-8") as f:
-    module_ast = ast.parse(f.read(), filename="main.py")
-
-_extract_from_json_ld = None
-for node in module_ast.body:
-    if isinstance(node, ast.FunctionDef) and node.name == "_extract_from_json_ld":
-        func_module = ast.Module(body=[node], type_ignores=[])
-        code = compile(func_module, filename="main.py", mode="exec")
-        namespace = {"Dict": Dict, "Any": Any, "Optional": Optional}
-        exec(code, namespace)
-        _extract_from_json_ld = namespace["_extract_from_json_ld"]
-        break
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from utils.json_ld import _extract_from_json_ld
 
 
 def test_extract_from_json_ld_missing_nutrition_returns_none():
@@ -54,3 +40,4 @@ def test_extract_from_json_ld_nested_objects_parsed():
         "carbs_100g": 2.0,
     }
     assert _extract_from_json_ld(data) == expected
+

--- a/utils/json_ld.py
+++ b/utils/json_ld.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, Optional
+
+
+def _extract_from_json_ld(data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Извлекает данные из JSON-LD структуры"""
+    if not isinstance(data, dict):
+        return None
+
+    name = (data.get("name") or data.get("headline") or "").strip()
+    brand = data.get("brand")
+    if isinstance(brand, dict):
+        brand = brand.get("name")
+
+    nutrition = data.get("nutrition") or {}
+
+    def get_nutrition_value(key):
+        value = nutrition.get(key)
+        if isinstance(value, dict):
+            value = value.get("@value") or value.get("value")
+        try:
+            return float(str(value).replace(',', '.')) if value is not None else None
+        except:
+            return None
+
+    kcal = (
+        get_nutrition_value("calories")
+        or get_nutrition_value("energy")
+        or get_nutrition_value("caloriesContent")
+    )
+    protein = get_nutrition_value("proteinContent")
+    fat = get_nutrition_value("fatContent")
+    carbs = get_nutrition_value("carbohydrateContent")
+
+    if any(v is not None for v in (kcal, protein, fat, carbs)):
+        return {
+            "name": name or "Продукт",
+            "brand": brand,
+            "kcal_100g": kcal,
+            "protein_100g": protein,
+            "fat_100g": fat,
+            "carbs_100g": carbs,
+        }
+    return None
+


### PR DESCRIPTION
## Summary
- move `_extract_from_json_ld` into `utils/json_ld.py`
- import helper from new module in `main.py`
- simplify JSON-LD tests to import helper directly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b86717e400832daf8942d820b93a31