### PR TITLE
Add Dockerfile for Python app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY . /app
+CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary
- add Dockerfile for building Python 3.11 container

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b87274fa14832db99d6a2a9bf36676