### PR TITLE
docs: clarify Cloud Run health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ gcloud builds submit --tag gcr.io/<PROJECT_ID>/healco-lite
 gcloud run deploy healco-lite \
   --image gcr.io/<PROJECT_ID>/healco-lite \
   --region <REGION> \
-  --set-env-vars OPENAI_API_KEY=...,TELEGRAM_BOT_TOKEN=...,TELEGRAM_PAYMENT_PROVIDER_TOKEN=... \
+  --port 8080 \
+  --set-env-vars PORT=8080,OPENAI_API_KEY=...,TELEGRAM_BOT_TOKEN=...,TELEGRAM_PAYMENT_PROVIDER_TOKEN=... \
+  --health-check-http-path /healthz \
   --allow-unauthenticated
+```
+
+При долгой инициализации можно увеличить таймауты проверок здоровья, например:
+
+```bash
+gcloud run services update healco-lite \
+  --health-check-initial-delay 180 \
+  --health-check-timeout 60
 ```


### PR DESCRIPTION
## Summary
- document Cloud Run deployment with explicit port and /healthz check
- note how to extend health-check timeouts for slow startups

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b993401a1c832d9ca59ca518e2e3f9