### PR TITLE
Pin openfoodfacts dependency version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ requests-oauthlib>=1.3.1
 beautifulsoup4>=4.12.2
 pydantic==2.7.4
 pydantic-core==2.18.4
-openfoodfacts
+openfoodfacts==2.9.0


### PR DESCRIPTION
## Summary
- pin openfoodfacts to version 2.9.0 in requirements

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`
- `docker build -t healco_lite .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9934a72dc832d92eba61c791a6d61