### PR TITLE
Fix run_webhook argument for PTB v21.4

### DIFF
--- a/main.py
+++ b/main.py
@@ -6427,13 +6427,10 @@ def main():
         if run_mode == "webhook":
             port = int(os.environ.get("PORT", "8080"))
             webhook_path = f"/webhook/{BOT_TOKEN}"
-            web_app = web.Application()
-            _add_healthz(web_app)
             app.run_webhook(
                 listen="0.0.0.0",
                 port=port,
-                webhook_path=webhook_path,
-                web_app=web_app,
+                url_path=webhook_path,
                 secret_token=os.environ.get("WEBHOOK_SECRET") or None,
                 drop_pending_updates=True,
             )


### PR DESCRIPTION
## Summary
- use correct `url_path` argument when starting webhook
- remove unsupported `web_app` usage

## Testing
- `pytest -q`
- `TELEGRAM_BOT_TOKEN=123456:ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AB RUN_MODE=webhook WEBHOOK_SECRET=secret OPENAI_API_KEY=dummy python main.py` *(fails: `httpx.ProxyError: 403 Forbidden`)*

------
https://chatgpt.com/codex/tasks/task_e_68b9934440b0832d8b11caa714d70d26