### PR TITLE
Clarify Cloud Run service name

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,6 @@
 substitutions:
   _IMAGE_NAME: "healcoeu3"                 # имя образа
+  _SERVICE_NAME: "healcoeu3"               # имя сервиса Cloud Run
   _REGION: "europe-west3"                  # регион AR и Cloud Run
   _REPO: "healco-lite-repo"                # репозиторий в Artifact Registry
 
@@ -24,7 +25,7 @@ steps:
     args:
       - run
       - deploy
-      - "healcoeu3"                                 # имя сервиса Cloud Run
+      - "${_SERVICE_NAME}"                               # имя сервиса Cloud Run
       - "--image"
       - "${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_IMAGE_NAME}:$SHORT_SHA"
       - "--region"


### PR DESCRIPTION
## Summary
- ensure Cloud Run deployment uses the healcoeu3 service name via a dedicated substitution variable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9bdc7bbb8832db94b6dc53409a9b5