### PR TITLE
Define Open Food Facts user-agent before imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,6 +36,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger("healco-lite")
 
+OPENFOOD_USER_AGENT = "HealCoLite/1.0 (rafael.sayadi@gmail.com)"
+
 # Импортируем Open Food Facts модуль
 try:
     import openfoodfacts
@@ -108,7 +110,6 @@ def log_egress_ip_once():
 VERSION = "healco lite v1.2"
 PROJECT_NAME = "Healco Lite v1.2"
 MODEL_NAME = "gpt-4o-mini"
-OPENFOOD_USER_AGENT = "HealCoLite/1.0 (rafael.sayadi@gmail.com)"
 
 # ========= ENV =========
 load_dotenv()


### PR DESCRIPTION
## Summary
- Move `OPENFOOD_USER_AGENT` definition above Open Food Facts imports so it exists before any `set_user_agent` calls.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9de6404a0832da7da75582ea925a3