### PR TITLE
refactor: remove hard-coded USDA API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip install .
 - `GOOGLE_CSE_KEY` — API‑ключ Google Custom Search.
 - `GOOGLE_CSE_CX` — идентификатор поисковой системы Google CSE.
 - `VISION_KEY` — ключ API для распознавания изображений (опционально).
-- `USDA_FDC_API_KEY` — ключ USDA FoodData Central.
+- `USDA_FDC_API_KEY` — ключ USDA FoodData Central. Его необходимо указать через одноимённую переменную окружения; в коде он не хранится.
 - `EXTERNAL_JSONL_URL` — URL внешнего JSONL файла с данными (опционально).
 - `GDRIVE_ID` — идентификатор файла в Google Drive (опционально).
 - `FATSECRET_KEY` — ключ API FatSecret.

--- a/main.py
+++ b/main.py
@@ -170,7 +170,7 @@ DISABLE_LOCAL_DB = True  # ← принудительно выключаем л�
 GOOGLE_CSE_KEY = get_secret("GOOGLE_CSE_KEY", "")
 GOOGLE_CSE_CX  = get_secret("GOOGLE_CSE_CX", "")
 VISION_KEY     = get_secret("VISION_KEY", "")        # опционально
-USDA_API_KEY   = get_secret("USDA_FDC_API_KEY", "cOQTpuHzZ2aOOpixNXoi8f5n94nEu5RvRoGf3o88")
+USDA_API_KEY   = get_secret("USDA_FDC_API_KEY", "")  # USDA FoodData Central API key
 
 class LocalDB:
     def __init__(self, path="db.json"):


### PR DESCRIPTION
## Summary
- remove hard-coded USDA FoodData Central API key and load from USDA_FDC_API_KEY env var
- document that USDA API key must be provided via USDA_FDC_API_KEY environment variable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9de677880832d91c2c90cb0450f9e