### PR TITLE
Skip keep-alive server on Cloud Run

### DIFF
--- a/main.py
+++ b/main.py
@@ -6248,6 +6248,16 @@ async def handle_onboarding(update: Update, context: ContextTypes.DEFAULT_TYPE, 
 
 # ========= KEEP‑ALIVE HTTP СЕРВЕР =========
 def start_keepalive_server():
+    """Запускает keep‑alive сервер, если он необходим.
+
+    На Cloud Run (где переменная окружения ``CLOUD_RUN=true``)
+    отдельный keep‑alive не требуется, поэтому выходим сразу,
+    оставляя порт 8080 свободным для основного приложения.
+    """
+    if os.environ.get("CLOUD_RUN", "").lower() == "true":
+        logger.info("Cloud Run detected, skipping keep‑alive server")
+        return
+
     # Используем уже импортированный keep_alive модуль
     try:
         import keep_alive


### PR DESCRIPTION
## Summary
- Skip launching keep-alive when `CLOUD_RUN=true`

## Testing
- `pytest -q`
- `python - <<'PY'
import os
from main import start_keepalive_server
os.environ['CLOUD_RUN']='true'
start_keepalive_server()
PY`


------
https://chatgpt.com/codex/tasks/task_e_68baa7526184832dbd1800ab2aaa3972