### PR TITLE
Add health check endpoint for Cloud Run

### DIFF
--- a/main.py
+++ b/main.py
@@ -6284,6 +6284,8 @@ def main():
 
         app = Application.builder().token(BOT_TOKEN).concurrent_updates(True).build()
 
+        _add_healthz(app.web_app)
+
         app.add_handler(CommandHandler("start", start))
         app.add_handler(CommandHandler("help", help_cmd))
         app.add_handler(CommandHandler("whoami", whoami_cmd))


### PR DESCRIPTION
## Summary
- register `/healthz` route on the web app to support Cloud Run health checks

## Testing
- `pytest -q`
- `python - <<'PY'
from aiohttp import web
from main import _add_healthz
import asyncio
from aiohttp.test_utils import TestClient, TestServer

app = web.Application()
_add_healthz(app)

async def main_test():
    async with TestClient(TestServer(app)) as client:
        resp = await client.get('/healthz')
        text = await resp.text()
        print(resp.status, text)

asyncio.run(main_test())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68baa7535474832d9eca063644086b82