### PR TITLE
docs: expose port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
 COPY . /app
+EXPOSE 8080
 CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary
- expose default port for Cloud Run documentation

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68babcac6f28832db27c52a38d5ea8e1