### PR TITLE
feat: add secret manager support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ beautifulsoup4>=4.12.2
 pydantic==2.7.4
 pydantic-core==2.18.4
 openfoodfacts==2.9.0
+google-cloud-secret-manager>=2.0.0

--- a/utils/config.py
+++ b/utils/config.py
@@ -4,20 +4,37 @@ from __future__ import annotations
 
 import os
 from dotenv import load_dotenv
+from google.cloud import secretmanager
 
 # Load environment variables from a .env file if present.
 load_dotenv()
 
 
 def get_secret(key: str, default: str = "") -> str:
-    """Return a secret value from the environment.
+    """Return a secret value from the environment or Google Secret Manager.
 
-    This is a thin wrapper around :func:`os.getenv` that provides a default
-    value when the key is missing.  It mirrors the behaviour used throughout
-    the project and keeps the logic in a single place.
+    The function first checks the local environment variables. If the key is
+    not present it tries to access a secret with the same name in Google Cloud
+    Secret Manager. The project ID is taken from the ``GCP_PROJECT`` or
+    ``GOOGLE_CLOUD_PROJECT`` environment variable. If the secret cannot be
+    retrieved, ``default`` is returned.
     """
 
-    return os.getenv(key, default)
+    value = os.getenv(key)
+    if value is not None:
+        return value
+
+    project_id = os.getenv("GCP_PROJECT") or os.getenv("GOOGLE_CLOUD_PROJECT")
+    if project_id:
+        try:
+            client = secretmanager.SecretManagerServiceClient()
+            name = f"projects/{project_id}/secrets/{key}/versions/latest"
+            response = client.access_secret_version(name=name)
+            return response.payload.data.decode("utf-8")
+        except Exception:
+            pass
+
+    return default
 
 
 __all__ = ["get_secret"]


### PR DESCRIPTION
## Summary
- add google-cloud-secret-manager dependency
- use Secret Manager to fetch secrets when environment variables are missing

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement google-cloud-secret-manager>=2.0.0)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68babeeec478832da38f86c154439f72