### PR TITLE
Add psycopg2-binary dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pydantic==2.7.4
 pydantic-core==2.18.4
 openfoodfacts==2.9.0
 google-cloud-secret-manager>=2.0.0
+psycopg2-binary==2.9.9


### PR DESCRIPTION
## Summary
- add psycopg2-binary as a pinned dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bac2812ef4832d9f4ee1001f057f96