### PR TITLE
feat: add postgres support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ pytest
 - `FATSECRET_KEY` — ключ API FatSecret.
 - `FATSECRET_SECRET` — секрет API FatSecret.
 - `HLITE_DB_PATH` — путь к файлу локальной БД (по умолчанию `db.json`).
+- `DB_USER`, `DB_PASS`, `DB_NAME` — параметры подключения к PostgreSQL.
+- `INSTANCE_UNIX_SOCKET` — путь к Unix‑сокету Cloud SQL инстанса (например `project:region:instance`).
 
 ## Примеры запуска
 
@@ -59,10 +61,12 @@ gcloud run deploy healco-lite \
   --image gcr.io/<PROJECT_ID>/healco-lite \
   --region <REGION> \
   --port 8080 \
-  --set-env-vars PORT=8080,OPENAI_API_KEY=...,TELEGRAM_BOT_TOKEN=...,TELEGRAM_PAYMENT_PROVIDER_TOKEN=... \
+  --set-env-vars PORT=8080,OPENAI_API_KEY=...,TELEGRAM_BOT_TOKEN=...,TELEGRAM_PAYMENT_PROVIDER_TOKEN=...,DB_USER=...,DB_PASS=...,DB_NAME=...,INSTANCE_UNIX_SOCKET=project:region:instance \
   --health-check-http-path /healthz \
   --allow-unauthenticated
 ```
+
+На Cloud Run приложение подключается к базе данных через Unix‑сокет `/cloudsql/${INSTANCE_UNIX_SOCKET}`.
 
 При долгой инициализации можно увеличить таймауты проверок здоровья, например:
 

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ from openai import OpenAI
 
 from utils.config import get_secret
 from utils.logging import logger
-from utils.db import db_get, db_set, db_keys_prefix
+from utils.postgres import db_get, db_set, db_keys_prefix, init_db
 from utils.cache import _cache_get, _cache_put, CACHE_SCHEMA
 
 OPENFOOD_USER_AGENT = "HealCoLite/1.0 (rafael.sayadi@gmail.com)"
@@ -116,6 +116,9 @@ OPENAI_API_KEY = get_secret("OPENAI_API_KEY", "")
 BOT_TOKEN = get_secret("TELEGRAM_BOT_TOKEN", "")
 TELEGRAM_PAYMENT_PROVIDER_TOKEN = get_secret("TELEGRAM_PAYMENT_PROVIDER_TOKEN", "")
 DEVELOPER_USER_ID = int(get_secret("DEVELOPER_USER_ID", "0").split(",")[0]) if get_secret("DEVELOPER_USER_ID", "0").split(",")[0].isdigit() else 0
+
+# Ensure PostgreSQL key/value table exists
+init_db()
 
 # Admin users list - stored in database
 def get_admin_users() -> List[int]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pydantic==2.7.4",
     "pydantic-core==2.18.4",
     "openfoodfacts==2.9.0",
+    "psycopg2-binary>=2.9",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pydantic==2.7.4
 pydantic-core==2.18.4
 openfoodfacts==2.9.0
 google-cloud-secret-manager>=2.0.0
+psycopg2-binary>=2.9

--- a/search.py
+++ b/search.py
@@ -23,7 +23,6 @@ from utils.consts import (
     SEARCH_CACHE_TTL,
     USER_AGENT,
 )
-from utils.db import DB
 from utils.logging import logger
 from utils.utils import (
     _extract_barcode,

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -4,7 +4,7 @@ functions for the HealCo Lite project."""
 from .config import get_secret
 from .logging import logger
 from .cache import _cache_get, _cache_put, CACHE_SCHEMA
-from .db import DB, db_get, db_set, db_keys_prefix
+from .postgres import db_get, db_set, db_keys_prefix
 from . import consts
 from .utils import (
     _extract_barcode,
@@ -34,7 +34,6 @@ __all__ = [
     "_cache_get",
     "_cache_put",
     "CACHE_SCHEMA",
-    "DB",
     "db_get",
     "db_set",
     "db_keys_prefix",

--- a/utils/postgres.py
+++ b/utils/postgres.py
@@ -1,0 +1,79 @@
+import os
+from contextlib import contextmanager
+from typing import Any, List
+
+import psycopg2
+from psycopg2.extras import Json
+
+
+DB_USER = os.getenv("DB_USER")
+DB_PASS = os.getenv("DB_PASS")
+DB_NAME = os.getenv("DB_NAME")
+INSTANCE_UNIX_SOCKET = os.getenv("INSTANCE_UNIX_SOCKET")
+
+
+def get_connection():
+    """Create a new database connection using environment variables."""
+    host = f"/cloudsql/{INSTANCE_UNIX_SOCKET}" if INSTANCE_UNIX_SOCKET else None
+    return psycopg2.connect(user=DB_USER, password=DB_PASS, dbname=DB_NAME, host=host)
+
+
+@contextmanager
+def get_cursor():
+    """Context manager yielding a cursor and handling connection lifecycle."""
+    conn = get_connection()
+    try:
+        with conn.cursor() as cur:
+            yield cur
+            conn.commit()
+    finally:
+        conn.close()
+
+
+def init_db() -> None:
+    """Initialize key/value storage table if it does not exist."""
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS kv_store (
+                key TEXT PRIMARY KEY,
+                value JSONB
+            )
+            """
+        )
+
+
+def db_get(key: str, default: Any = None) -> Any:
+    with get_cursor() as cur:
+        cur.execute("SELECT value FROM kv_store WHERE key=%s", (key,))
+        row = cur.fetchone()
+    if row:
+        return row[0]
+    return default
+
+
+def db_set(key: str, value: Any) -> None:
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO kv_store (key, value) VALUES (%s, %s)
+            ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
+            """,
+            (key, Json(value)),
+        )
+
+
+def db_keys_prefix(prefix: str) -> List[str]:
+    with get_cursor() as cur:
+        cur.execute("SELECT key FROM kv_store WHERE key LIKE %s", (prefix + "%",))
+        return [r[0] for r in cur.fetchall()]
+
+
+__all__ = [
+    "get_connection",
+    "get_cursor",
+    "init_db",
+    "db_get",
+    "db_set",
+    "db_keys_prefix",
+]


### PR DESCRIPTION
## Summary
- add PostgreSQL helper module using psycopg2 and env configuration
- switch bot state and admin storage to PostgreSQL
- document database environment variables and Cloud Run socket usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bac2829544832db6bf77e29efc6a92